### PR TITLE
Home scene 데이터 연결 구현

### DIFF
--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		D2525A332887DC3800078D1C /* ViewDefaultMyPageUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */; };
 		D2525A372887DC9300078D1C /* ViewMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */; };
 		D2525A392887DCB400078D1C /* ViewDefaultMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */; };
+		D2525A3B2887DE6100078D1C /* JSONConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A3A2887DE6100078D1C /* JSONConverter.swift */; };
 		D2623523287BC06B002F0610 /* DetailProfileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623522287BC06B002F0610 /* DetailProfileSection.swift */; };
 		D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */; };
 		D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623526287BF572002F0610 /* CollectionViewDatasource.swift */; };
@@ -75,6 +76,7 @@
 		D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDefaultMyPageUsecase.swift; sourceTree = "<group>"; };
 		D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMyPageRepository.swift; sourceTree = "<group>"; };
 		D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDefaultMyPageRepository.swift; sourceTree = "<group>"; };
+		D2525A3A2887DE6100078D1C /* JSONConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONConverter.swift; sourceTree = "<group>"; };
 		D2623522287BC06B002F0610 /* DetailProfileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileSection.swift; sourceTree = "<group>"; };
 		D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2623526287BF572002F0610 /* CollectionViewDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDatasource.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 			isa = PBXGroup;
 			children = (
 				D2623559287E97F0002F0610 /* Observable.swift */,
+				D2525A3A2887DE6100078D1C /* JSONConverter.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -514,6 +517,7 @@
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
 				D2525A392887DCB400078D1C /* ViewDefaultMyPageRepository.swift in Sources */,
 				B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */,
+				D2525A3B2887DE6100078D1C /* JSONConverter.swift in Sources */,
 				D2623541287D6049002F0610 /* LoginViewController.swift in Sources */,
 				B37747DB287BBA0200E2599B /* HomeViewController.swift in Sources */,
 				D262354D287D7DF0002F0610 /* NetworkError.swift in Sources */,

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		B3F23FEF287D622800E06E85 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F23FEE287D622800E06E85 /* HTTPMethod.swift */; };
 		D24B348E2886A25D00F8243F /* OAuthLoginUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B348D2886A25D00F8243F /* OAuthLoginUsecase.swift */; };
 		D24B34902886A2F200F8243F /* InstagramLoginUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B348F2886A2F200F8243F /* InstagramLoginUsecase.swift */; };
+		D2525A282887D2D100078D1C /* UserPageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A272887D2D100078D1C /* UserPageDTO.swift */; };
+		D2525A2A2887D3A400078D1C /* MediaDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A292887D3A400078D1C /* MediaDTO.swift */; };
+		D2525A2C2887D3EC00078D1C /* MediaPagingDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */; };
 		D2623523287BC06B002F0610 /* DetailProfileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623522287BC06B002F0610 /* DetailProfileSection.swift */; };
 		D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */; };
 		D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623526287BF572002F0610 /* CollectionViewDatasource.swift */; };
@@ -59,6 +62,9 @@
 		B3F23FEE287D622800E06E85 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		D24B348D2886A25D00F8243F /* OAuthLoginUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthLoginUsecase.swift; sourceTree = "<group>"; };
 		D24B348F2886A2F200F8243F /* InstagramLoginUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstagramLoginUsecase.swift; sourceTree = "<group>"; };
+		D2525A272887D2D100078D1C /* UserPageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPageDTO.swift; sourceTree = "<group>"; };
+		D2525A292887D3A400078D1C /* MediaDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDTO.swift; sourceTree = "<group>"; };
+		D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPagingDTO.swift; sourceTree = "<group>"; };
 		D2623522287BC06B002F0610 /* DetailProfileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileSection.swift; sourceTree = "<group>"; };
 		D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2623526287BF572002F0610 /* CollectionViewDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDatasource.swift; sourceTree = "<group>"; };
@@ -165,6 +171,16 @@
 				D24B348D2886A25D00F8243F /* OAuthLoginUsecase.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		D2525A262887D27300078D1C /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A272887D2D100078D1C /* UserPageDTO.swift */,
+				D2525A292887D3A400078D1C /* MediaDTO.swift */,
+				D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */,
+			);
+			path = DTO;
 			sourceTree = "<group>";
 		};
 		D2623538287D145A002F0610 /* DetailScene */ = {
@@ -299,6 +315,7 @@
 		D2623557287E9760002F0610 /* DataLayer */ = {
 			isa = PBXGroup;
 			children = (
+				D2525A262887D27300078D1C /* DTO */,
 				B3F23FE9287D602500E06E85 /* Network */,
 			);
 			path = DataLayer;
@@ -433,6 +450,7 @@
 				B37747E1287C146000E2599B /* PostCell.swift in Sources */,
 				D262352B287C0203002F0610 /* DetailButtonSection.swift in Sources */,
 				B3F149B1287AB6AD0072DA45 /* DetailViewController.swift in Sources */,
+				D2525A2C2887D3EC00078D1C /* MediaPagingDTO.swift in Sources */,
 				D2623523287BC06B002F0610 /* DetailProfileSection.swift in Sources */,
 				D2623552287D8183002F0610 /* NetworkServiceable.swift in Sources */,
 				D262354B287D7B02002F0610 /* NetworkService.swift in Sources */,
@@ -448,6 +466,8 @@
 				D24B34902886A2F200F8243F /* InstagramLoginUsecase.swift in Sources */,
 				B3F23FEF287D622800E06E85 /* HTTPMethod.swift in Sources */,
 				D2623544287D6DCC002F0610 /* LoginViewModel.swift in Sources */,
+				D2525A282887D2D100078D1C /* UserPageDTO.swift in Sources */,
+				D2525A2A2887D3A400078D1C /* MediaDTO.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
 				B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */,
 				D2623541287D6049002F0610 /* LoginViewController.swift in Sources */,

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		D2525A372887DC9300078D1C /* ViewMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */; };
 		D2525A392887DCB400078D1C /* ViewDefaultMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */; };
 		D2525A3B2887DE6100078D1C /* JSONConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A3A2887DE6100078D1C /* JSONConverter.swift */; };
+		D2525A3E2887E4C100078D1C /* UserPageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A3D2887E4C100078D1C /* UserPageEntity.swift */; };
+		D2525A402887E50A00078D1C /* MediaEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A3F2887E50A00078D1C /* MediaEntity.swift */; };
+		D2525A422887E7E600078D1C /* MediaImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A412887E7E600078D1C /* MediaImageEntity.swift */; };
 		D2623523287BC06B002F0610 /* DetailProfileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623522287BC06B002F0610 /* DetailProfileSection.swift */; };
 		D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */; };
 		D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623526287BF572002F0610 /* CollectionViewDatasource.swift */; };
@@ -77,6 +80,9 @@
 		D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMyPageRepository.swift; sourceTree = "<group>"; };
 		D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDefaultMyPageRepository.swift; sourceTree = "<group>"; };
 		D2525A3A2887DE6100078D1C /* JSONConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONConverter.swift; sourceTree = "<group>"; };
+		D2525A3D2887E4C100078D1C /* UserPageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPageEntity.swift; sourceTree = "<group>"; };
+		D2525A3F2887E50A00078D1C /* MediaEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEntity.swift; sourceTree = "<group>"; };
+		D2525A412887E7E600078D1C /* MediaImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageEntity.swift; sourceTree = "<group>"; };
 		D2623522287BC06B002F0610 /* DetailProfileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileSection.swift; sourceTree = "<group>"; };
 		D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2623526287BF572002F0610 /* CollectionViewDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDatasource.swift; sourceTree = "<group>"; };
@@ -222,6 +228,16 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		D2525A3C2887E4B500078D1C /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A3D2887E4C100078D1C /* UserPageEntity.swift */,
+				D2525A3F2887E50A00078D1C /* MediaEntity.swift */,
+				D2525A412887E7E600078D1C /* MediaImageEntity.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
 		D2623538287D145A002F0610 /* DetailScene */ = {
 			isa = PBXGroup;
 			children = (
@@ -347,6 +363,7 @@
 		D2623556287E9745002F0610 /* DomainLayer */ = {
 			isa = PBXGroup;
 			children = (
+				D2525A3C2887E4B500078D1C /* Entity */,
 				D24B348B2886A23000F8243F /* LoginUsecase */,
 			);
 			path = DomainLayer;
@@ -502,12 +519,15 @@
 				D262352F287C0D71002F0610 /* DetailDescriptionSection.swift in Sources */,
 				B3F149AD287AB6AD0072DA45 /* AppDelegate.swift in Sources */,
 				D262353E287D17DA002F0610 /* UIStackView +.swift in Sources */,
+				D2525A402887E50A00078D1C /* MediaEntity.swift in Sources */,
+				D2525A422887E7E600078D1C /* MediaImageEntity.swift in Sources */,
 				D2525A332887DC3800078D1C /* ViewDefaultMyPageUsecase.swift in Sources */,
 				D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */,
 				D2525A312887DC0F00078D1C /* ViewMyPageUsecase.swift in Sources */,
 				D262352D287C03DC002F0610 /* UIView +.swift in Sources */,
 				B3F23FEB287D607E00E06E85 /* Endpoint.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
+				D2525A3E2887E4C100078D1C /* UserPageEntity.swift in Sources */,
 				B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */,
 				D24B34902886A2F200F8243F /* InstagramLoginUsecase.swift in Sources */,
 				B3F23FEF287D622800E06E85 /* HTTPMethod.swift in Sources */,

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -381,9 +381,9 @@
 		D2623556287E9745002F0610 /* DomainLayer */ = {
 			isa = PBXGroup;
 			children = (
+				D24B348B2886A23000F8243F /* LoginUsecase */,
 				B3AD441E2887F15F00A9B59E /* HomeUsecase */,
 				D2525A3C2887E4B500078D1C /* Entity */,
-				D24B348B2886A23000F8243F /* LoginUsecase */,
 			);
 			path = DomainLayer;
 			sourceTree = "<group>";

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B37747DD287BBCC800E2599B /* HomeNavigationTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DC287BBCC800E2599B /* HomeNavigationTitleView.swift */; };
 		B37747DF287BED7D00E2599B /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DE287BED7C00E2599B /* ProfileView.swift */; };
 		B37747E1287C146000E2599B /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747E0287C146000E2599B /* PostCell.swift */; };
+		B3AD44212887F7BA00A9B59E /* MediaUrlDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AD44202887F7BA00A9B59E /* MediaUrlDTO.swift */; };
 		B3F149AD287AB6AD0072DA45 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149AC287AB6AD0072DA45 /* AppDelegate.swift */; };
 		B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149AE287AB6AD0072DA45 /* SceneDelegate.swift */; };
 		B3F149B1287AB6AD0072DA45 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149B0287AB6AD0072DA45 /* DetailViewController.swift */; };
@@ -58,6 +59,7 @@
 		B37747DC287BBCC800E2599B /* HomeNavigationTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationTitleView.swift; sourceTree = "<group>"; };
 		B37747DE287BED7C00E2599B /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		B37747E0287C146000E2599B /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
+		B3AD44202887F7BA00A9B59E /* MediaUrlDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUrlDTO.swift; sourceTree = "<group>"; };
 		B3F149A9287AB6AD0072DA45 /* Czechgram.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Czechgram.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3F149AC287AB6AD0072DA45 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B3F149AE287AB6AD0072DA45 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -129,6 +131,23 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		B3AD441E2887F15F00A9B59E /* HomeUsecase */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */,
+				B3AD441F2887F17E00A9B59E /* Protocol */,
+			);
+			path = HomeUsecase;
+			sourceTree = "<group>";
+		};
+		B3AD441F2887F17E00A9B59E /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		B3F149A0287AB6AD0072DA45 = {
 			isa = PBXGroup;
 			children = (
@@ -178,7 +197,6 @@
 			isa = PBXGroup;
 			children = (
 				D24B348F2886A2F200F8243F /* InstagramLoginUsecase.swift */,
-				D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */,
 				D24B348C2886A24F00F8243F /* Protocol */,
 			);
 			path = LoginUsecase;
@@ -188,7 +206,6 @@
 			isa = PBXGroup;
 			children = (
 				D24B348D2886A25D00F8243F /* OAuthLoginUsecase.swift */,
-				D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -199,6 +216,7 @@
 				D2525A272887D2D100078D1C /* UserPageDTO.swift */,
 				D2525A292887D3A400078D1C /* MediaDTO.swift */,
 				D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */,
+				B3AD44202887F7BA00A9B59E /* MediaUrlDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -363,6 +381,7 @@
 		D2623556287E9745002F0610 /* DomainLayer */ = {
 			isa = PBXGroup;
 			children = (
+				B3AD441E2887F15F00A9B59E /* HomeUsecase */,
 				D2525A3C2887E4B500078D1C /* Entity */,
 				D24B348B2886A23000F8243F /* LoginUsecase */,
 			);
@@ -525,6 +544,7 @@
 				D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */,
 				D2525A312887DC0F00078D1C /* ViewMyPageUsecase.swift in Sources */,
 				D262352D287C03DC002F0610 /* UIView +.swift in Sources */,
+				B3AD44212887F7BA00A9B59E /* MediaUrlDTO.swift in Sources */,
 				B3F23FEB287D607E00E06E85 /* Endpoint.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
 				D2525A3E2887E4C100078D1C /* UserPageEntity.swift in Sources */,

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		B37747DF287BED7D00E2599B /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DE287BED7C00E2599B /* ProfileView.swift */; };
 		B37747E1287C146000E2599B /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747E0287C146000E2599B /* PostCell.swift */; };
 		B3AD44212887F7BA00A9B59E /* MediaUrlDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AD44202887F7BA00A9B59E /* MediaUrlDTO.swift */; };
+		B3F115BF2888F7A1001B498C /* ImageCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F115BE2888F7A1001B498C /* ImageCacheService.swift */; };
+		B3F115C12888F7D1001B498C /* FileCachedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F115C02888F7D1001B498C /* FileCachedService.swift */; };
 		B3F149AD287AB6AD0072DA45 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149AC287AB6AD0072DA45 /* AppDelegate.swift */; };
 		B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149AE287AB6AD0072DA45 /* SceneDelegate.swift */; };
 		B3F149B1287AB6AD0072DA45 /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F149B0287AB6AD0072DA45 /* DetailViewController.swift */; };
@@ -60,6 +62,8 @@
 		B37747DE287BED7C00E2599B /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		B37747E0287C146000E2599B /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
 		B3AD44202887F7BA00A9B59E /* MediaUrlDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUrlDTO.swift; sourceTree = "<group>"; };
+		B3F115BE2888F7A1001B498C /* ImageCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheService.swift; sourceTree = "<group>"; };
+		B3F115C02888F7D1001B498C /* FileCachedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCachedService.swift; sourceTree = "<group>"; };
 		B3F149A9287AB6AD0072DA45 /* Czechgram.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Czechgram.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3F149AC287AB6AD0072DA45 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B3F149AE287AB6AD0072DA45 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -146,6 +150,15 @@
 				D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		B3F115BA2888F708001B498C /* FileManager */ = {
+			isa = PBXGroup;
+			children = (
+				B3F115BE2888F7A1001B498C /* ImageCacheService.swift */,
+				B3F115C02888F7D1001B498C /* FileCachedService.swift */,
+			);
+			path = FileManager;
 			sourceTree = "<group>";
 		};
 		B3F149A0287AB6AD0072DA45 = {
@@ -391,6 +404,7 @@
 		D2623557287E9760002F0610 /* DataLayer */ = {
 			isa = PBXGroup;
 			children = (
+				B3F115BA2888F708001B498C /* FileManager */,
 				D2525A262887D27300078D1C /* DTO */,
 				D2525A342887DC7800078D1C /* Repository */,
 				B3F23FE9287D602500E06E85 /* Network */,
@@ -544,6 +558,7 @@
 				D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */,
 				D2525A312887DC0F00078D1C /* ViewMyPageUsecase.swift in Sources */,
 				D262352D287C03DC002F0610 /* UIView +.swift in Sources */,
+				B3F115BF2888F7A1001B498C /* ImageCacheService.swift in Sources */,
 				B3AD44212887F7BA00A9B59E /* MediaUrlDTO.swift in Sources */,
 				B3F23FEB287D607E00E06E85 /* Endpoint.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
@@ -559,6 +574,7 @@
 				B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */,
 				D2525A3B2887DE6100078D1C /* JSONConverter.swift in Sources */,
 				D2623541287D6049002F0610 /* LoginViewController.swift in Sources */,
+				B3F115C12888F7D1001B498C /* FileCachedService.swift in Sources */,
 				B37747DB287BBA0200E2599B /* HomeViewController.swift in Sources */,
 				D262354D287D7DF0002F0610 /* NetworkError.swift in Sources */,
 				B37747DF287BED7D00E2599B /* ProfileView.swift in Sources */,

--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -26,6 +26,11 @@
 		D2525A282887D2D100078D1C /* UserPageDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A272887D2D100078D1C /* UserPageDTO.swift */; };
 		D2525A2A2887D3A400078D1C /* MediaDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A292887D3A400078D1C /* MediaDTO.swift */; };
 		D2525A2C2887D3EC00078D1C /* MediaPagingDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */; };
+		D2525A2F2887DBC700078D1C /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A2E2887DBC700078D1C /* HomeViewModel.swift */; };
+		D2525A312887DC0F00078D1C /* ViewMyPageUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */; };
+		D2525A332887DC3800078D1C /* ViewDefaultMyPageUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */; };
+		D2525A372887DC9300078D1C /* ViewMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */; };
+		D2525A392887DCB400078D1C /* ViewDefaultMyPageRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */; };
 		D2623523287BC06B002F0610 /* DetailProfileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623522287BC06B002F0610 /* DetailProfileSection.swift */; };
 		D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */; };
 		D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2623526287BF572002F0610 /* CollectionViewDatasource.swift */; };
@@ -65,6 +70,11 @@
 		D2525A272887D2D100078D1C /* UserPageDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPageDTO.swift; sourceTree = "<group>"; };
 		D2525A292887D3A400078D1C /* MediaDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDTO.swift; sourceTree = "<group>"; };
 		D2525A2B2887D3EC00078D1C /* MediaPagingDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPagingDTO.swift; sourceTree = "<group>"; };
+		D2525A2E2887DBC700078D1C /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMyPageUsecase.swift; sourceTree = "<group>"; };
+		D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDefaultMyPageUsecase.swift; sourceTree = "<group>"; };
+		D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMyPageRepository.swift; sourceTree = "<group>"; };
+		D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDefaultMyPageRepository.swift; sourceTree = "<group>"; };
 		D2623522287BC06B002F0610 /* DetailProfileSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailProfileSection.swift; sourceTree = "<group>"; };
 		D2623524287BD0D4002F0610 /* DetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		D2623526287BF572002F0610 /* CollectionViewDatasource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDatasource.swift; sourceTree = "<group>"; };
@@ -160,6 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				D24B348F2886A2F200F8243F /* InstagramLoginUsecase.swift */,
+				D2525A322887DC3800078D1C /* ViewDefaultMyPageUsecase.swift */,
 				D24B348C2886A24F00F8243F /* Protocol */,
 			);
 			path = LoginUsecase;
@@ -169,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				D24B348D2886A25D00F8243F /* OAuthLoginUsecase.swift */,
+				D2525A302887DC0F00078D1C /* ViewMyPageUsecase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -183,6 +195,31 @@
 			path = DTO;
 			sourceTree = "<group>";
 		};
+		D2525A2D2887DBBB00078D1C /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A2E2887DBC700078D1C /* HomeViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		D2525A342887DC7800078D1C /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A382887DCB400078D1C /* ViewDefaultMyPageRepository.swift */,
+				D2525A352887DC8000078D1C /* Protocol */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		D2525A352887DC8000078D1C /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				D2525A362887DC9300078D1C /* ViewMyPageRepository.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		D2623538287D145A002F0610 /* DetailScene */ = {
 			isa = PBXGroup;
 			children = (
@@ -194,6 +231,7 @@
 		D2623539287D15D7002F0610 /* HomeScene */ = {
 			isa = PBXGroup;
 			children = (
+				D2525A2D2887DBBB00078D1C /* ViewModel */,
 				D262353B287D1626002F0610 /* View */,
 			);
 			path = HomeScene;
@@ -316,6 +354,7 @@
 			isa = PBXGroup;
 			children = (
 				D2525A262887D27300078D1C /* DTO */,
+				D2525A342887DC7800078D1C /* Repository */,
 				B3F23FE9287D602500E06E85 /* Network */,
 			);
 			path = DataLayer;
@@ -444,9 +483,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2525A372887DC9300078D1C /* ViewMyPageRepository.swift in Sources */,
 				D24B348E2886A25D00F8243F /* OAuthLoginUsecase.swift in Sources */,
 				D262355A287E97F0002F0610 /* Observable.swift in Sources */,
 				B3F23FED287D609200E06E85 /* Endpontable.swift in Sources */,
+				D2525A2F2887DBC700078D1C /* HomeViewModel.swift in Sources */,
 				B37747E1287C146000E2599B /* PostCell.swift in Sources */,
 				D262352B287C0203002F0610 /* DetailButtonSection.swift in Sources */,
 				B3F149B1287AB6AD0072DA45 /* DetailViewController.swift in Sources */,
@@ -458,7 +499,9 @@
 				D262352F287C0D71002F0610 /* DetailDescriptionSection.swift in Sources */,
 				B3F149AD287AB6AD0072DA45 /* AppDelegate.swift in Sources */,
 				D262353E287D17DA002F0610 /* UIStackView +.swift in Sources */,
+				D2525A332887DC3800078D1C /* ViewDefaultMyPageUsecase.swift in Sources */,
 				D2623525287BD0D4002F0610 /* DetailCollectionViewCell.swift in Sources */,
+				D2525A312887DC0F00078D1C /* ViewMyPageUsecase.swift in Sources */,
 				D262352D287C03DC002F0610 /* UIView +.swift in Sources */,
 				B3F23FEB287D607E00E06E85 /* Endpoint.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
@@ -469,6 +512,7 @@
 				D2525A282887D2D100078D1C /* UserPageDTO.swift in Sources */,
 				D2525A2A2887D3A400078D1C /* MediaDTO.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
+				D2525A392887DCB400078D1C /* ViewDefaultMyPageRepository.swift in Sources */,
 				B3F149AF287AB6AD0072DA45 /* SceneDelegate.swift in Sources */,
 				D2623541287D6049002F0610 /* LoginViewController.swift in Sources */,
 				B37747DB287BBA0200E2599B /* HomeViewController.swift in Sources */,

--- a/Czechgram/Czechgram/DataLayer/DTO/MediaDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/MediaDTO.swift
@@ -1,0 +1,24 @@
+//
+//  MediaDTO.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+// MARK: - Media
+struct MediaDTO: Codable {
+    let mediaIDs: [MediaID]
+    let paging: MediaPagingDTO
+
+    enum CodingKeys: String, CodingKey {
+        case mediaIDs = "data"
+        case paging
+    }
+}
+
+// MARK: - Datum
+struct MediaID: Codable {
+    let id: String
+}

--- a/Czechgram/Czechgram/DataLayer/DTO/MediaPagingDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/MediaPagingDTO.swift
@@ -1,0 +1,14 @@
+//
+//  MediaPagingDTO.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+// MARK: - Paging
+struct MediaPagingDTO: Codable {
+    let next: String?
+    let previous: String?
+}

--- a/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct MediaUrlDTO: Codable{
+struct MediaUrlDTO: Codable {
     let id: String
     let mediaType: MediaType
     let mediaUrl: String
     let thumbnailUrl: String?
-    
+
     enum CodingKeys: String, CodingKey {
         case id
         case mediaType = "media_type"
@@ -26,4 +26,3 @@ enum MediaType: String, Codable {
     case Video = "VIDEO"
     case CarouselAlBum = "CAROUSEL_ALBUM"
 }
-

--- a/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
@@ -1,0 +1,29 @@
+//
+//  MediaUrlDTO.swift
+//  Czechgram
+//
+//  Created by 최예주 on 2022/07/20.
+//
+
+import Foundation
+
+struct MediaUrlDTO: Codable{
+    let id: String
+    let mediaType: MediaType
+    let mediaUrl: String
+    let thumbnailUrl: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case mediaType = "media_type"
+        case mediaUrl = "media_url"
+        case thumbnailUrl = "thumbnail_url"
+    }
+}
+
+enum MediaType: String, Codable {
+    case Image = "IMAGE"
+    case Video = "VIDEO"
+    case CarouselAlBum = "CAROUSEL_ALBUM"
+}
+

--- a/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/MediaUrlDTO.swift
@@ -12,12 +12,14 @@ struct MediaUrlDTO: Codable {
     let mediaType: MediaType
     let mediaUrl: String
     let thumbnailUrl: String?
+    let timestamp: String
 
     enum CodingKeys: String, CodingKey {
         case id
         case mediaType = "media_type"
         case mediaUrl = "media_url"
         case thumbnailUrl = "thumbnail_url"
+        case timestamp
     }
 }
 

--- a/Czechgram/Czechgram/DataLayer/DTO/UserPageDTO.swift
+++ b/Czechgram/Czechgram/DataLayer/DTO/UserPageDTO.swift
@@ -1,0 +1,21 @@
+//
+//  UserPageDTO.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+struct UserPageDTO: Codable {
+    let username: String
+    let mediaCount: Int
+    let media: MediaDTO
+    let id: String
+
+    enum CodingKeys: String, CodingKey {
+        case username
+        case mediaCount = "media_count"
+        case media, id
+    }
+}

--- a/Czechgram/Czechgram/DataLayer/FileManager/FileCachedService.swift
+++ b/Czechgram/Czechgram/DataLayer/FileManager/FileCachedService.swift
@@ -1,0 +1,51 @@
+//
+//  FileCachedService.swift
+//  Czechgram
+//
+//  Created by 최예주 on 2022/07/21.
+//
+
+import UIKit
+
+class FileCachedService {
+
+    static let shared = NSCache<NSString, NSData>()
+    static let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
+
+    static func saveData(data: NSData, createdTime: Date) {
+        shared.setObject(data, forKey: NSString(string: "\(createdTime)"))
+
+        guard let pathURL = path else { return }
+        let fileManager = FileManager()
+        var filePath = URL(fileURLWithPath: pathURL)
+        filePath.appendPathComponent("\(createdTime)")
+
+        guard !fileManager.fileExists(atPath: filePath.path) else { return }
+
+        fileManager.createFile(atPath: filePath.path, contents: data as Data)
+    }
+
+//    static func loadData(createdTime: Date) -> MediaImageEntity? {
+//        guard let data = shared.object(forKey: NSString(string: "\(createdTime)")) else {
+//
+//            guard let pathURL = path else { return nil }
+//            let fileManager = FileManager()
+//            var filePath = URL(fileURLWithPath: pathURL)
+//            filePath.appendPathComponent("\(createdTime)")
+//
+//            if fileManager.fileExists(atPath: filePath.path) {
+//                guard let mediaImageEntity = try? Data(contentsOf: filePath) else { return nil }
+//                let jsonConverter = JSONConverter<MediaImageEntity>()
+//
+//                return mediaImageEntity
+//            }
+//            else {
+//                return nil
+//            }
+//        }
+//        return data as? MediaImageEntity
+//
+//
+//    }
+
+}

--- a/Czechgram/Czechgram/DataLayer/FileManager/ImageCacheService.swift
+++ b/Czechgram/Czechgram/DataLayer/FileManager/ImageCacheService.swift
@@ -1,0 +1,49 @@
+//
+//  ImageCacheService.swift
+//  Czechgram
+//
+//  Created by 최예주 on 2022/07/21.
+//
+
+import UIKit
+
+class ImageCacheService {
+
+    static let shared = NSCache<NSString, UIImage>()
+    static let path = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
+
+    static func saveData(image: UIImage?, url: URL) {
+        guard let image = image else { return }
+        shared.setObject(image, forKey: url.lastPathComponent as NSString)
+        guard let pathURL = path else { return }
+
+        let fileManager = FileManager()
+        var filePath = URL(fileURLWithPath: pathURL)
+        filePath.appendPathComponent(url.lastPathComponent)
+
+        guard !fileManager.fileExists(atPath: filePath.path) else { return }
+
+        fileManager.createFile(atPath: filePath.path, contents: image.jpegData(compressionQuality: 0.5))
+        print("=>\(filePath)")
+
+    }
+
+    static func loadData(url: URL) -> UIImage? {
+        guard let cachedData = shared.object(forKey: url.lastPathComponent as NSString) else {
+
+            guard let pathURL = path else { return nil }
+            let fileManager = FileManager()
+            var filePath = URL(fileURLWithPath: pathURL)
+            filePath.appendPathComponent(url.lastPathComponent)
+
+            if fileManager.fileExists(atPath: pathURL) {
+                guard let imageData = try? Data(contentsOf: filePath) else { return nil }
+                return UIImage(data: imageData)
+            }
+            return nil
+        }
+
+        return cachedData
+    }
+
+}

--- a/Czechgram/Czechgram/DataLayer/FileManager/ImageCacheService.swift
+++ b/Czechgram/Czechgram/DataLayer/FileManager/ImageCacheService.swift
@@ -24,8 +24,6 @@ class ImageCacheService {
         guard !fileManager.fileExists(atPath: filePath.path) else { return }
 
         fileManager.createFile(atPath: filePath.path, contents: image.jpegData(compressionQuality: 0.5))
-        print("=>\(filePath)")
-
     }
 
     static func loadData(url: URL) -> UIImage? {

--- a/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
@@ -89,7 +89,7 @@ enum EndPoint: EndPontable {
                     URLQueryItem(name: "access_token", value: token)]
 
         case .imageUrl(_, let token):
-            return [URLQueryItem(name: "fields", value: "id,media_type,media_url,thumbnail_url"),
+            return [URLQueryItem(name: "fields", value: "id,media_type,media_url,thumbnail_url,timestamp"),
                     URLQueryItem(name: "access_token", value: token)]
         }
 

--- a/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
@@ -12,6 +12,7 @@ enum EndPoint: EndPontable {
     case instagramAuthorize
     case shortLivedToken(code: String)
     case longLivedToken(token: String)
+    case userPage(token: String)
 
     var scheme: String {
         return "https"
@@ -19,7 +20,7 @@ enum EndPoint: EndPontable {
 
     var host: String {
         switch self {
-        case .longLivedToken:
+        case .longLivedToken, .userPage:
             return "graph.instagram.com"
         default:
             return "api.instagram.com"
@@ -35,6 +36,8 @@ enum EndPoint: EndPontable {
             return "/oauth/access_token"
         case .longLivedToken:
             return "/access_token"
+        case .userPage:
+            return "/me"
         }
     }
 
@@ -49,10 +52,7 @@ enum EndPoint: EndPontable {
 
     var contentType: [String: String]? {
         switch self {
-        case .instagramAuthorize:
-            return ["Content-type": "application/json",
-                    "Accept": "application/json"]
-        case .longLivedToken:
+        case .instagramAuthorize, .longLivedToken, .userPage:
             return ["Content-type": "application/json",
                     "Accept": "application/json"]
         default:
@@ -79,6 +79,10 @@ enum EndPoint: EndPontable {
         case .longLivedToken(let token):
             return [URLQueryItem(name: "grant_type", value: "ig_exchange_token"),
                     URLQueryItem(name: "client_secret", value: "2b5c96cee7df4b0e8b5a8a291ed7d747"),
+                    URLQueryItem(name: "access_token", value: token)]
+            
+        case .userPage(let token):
+            return [URLQueryItem(name: "fields", value: "username,media_count,media"),
                     URLQueryItem(name: "access_token", value: token)]
         }
 

--- a/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
@@ -80,7 +80,7 @@ enum EndPoint: EndPontable {
             return [URLQueryItem(name: "grant_type", value: "ig_exchange_token"),
                     URLQueryItem(name: "client_secret", value: "2b5c96cee7df4b0e8b5a8a291ed7d747"),
                     URLQueryItem(name: "access_token", value: token)]
-            
+
         case .userPage(let token):
             return [URLQueryItem(name: "fields", value: "username,media_count,media"),
                     URLQueryItem(name: "access_token", value: token)]

--- a/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
@@ -87,12 +87,11 @@ enum EndPoint: EndPontable {
         case .userPage(let token):
             return [URLQueryItem(name: "fields", value: "username,media_count,media"),
                     URLQueryItem(name: "access_token", value: token)]
-            
+
         case .imageUrl(_, let token):
             return [URLQueryItem(name: "fields", value: "id,media_type,media_url,thumbnail_url"),
                     URLQueryItem(name: "access_token", value: token)]
         }
-        
 
     }
 

--- a/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/EndPoint/Endpoint.swift
@@ -13,6 +13,7 @@ enum EndPoint: EndPontable {
     case shortLivedToken(code: String)
     case longLivedToken(token: String)
     case userPage(token: String)
+    case imageUrl(mediaID: String, token: String)
 
     var scheme: String {
         return "https"
@@ -20,7 +21,7 @@ enum EndPoint: EndPontable {
 
     var host: String {
         switch self {
-        case .longLivedToken, .userPage:
+        case .longLivedToken, .userPage, .imageUrl:
             return "graph.instagram.com"
         default:
             return "api.instagram.com"
@@ -38,6 +39,8 @@ enum EndPoint: EndPontable {
             return "/access_token"
         case .userPage:
             return "/me"
+        case .imageUrl(let id, _):
+            return "/\(id)"
         }
     }
 
@@ -52,7 +55,7 @@ enum EndPoint: EndPontable {
 
     var contentType: [String: String]? {
         switch self {
-        case .instagramAuthorize, .longLivedToken, .userPage:
+        case .instagramAuthorize, .longLivedToken, .userPage, .imageUrl:
             return ["Content-type": "application/json",
                     "Accept": "application/json"]
         default:
@@ -84,7 +87,12 @@ enum EndPoint: EndPontable {
         case .userPage(let token):
             return [URLQueryItem(name: "fields", value: "username,media_count,media"),
                     URLQueryItem(name: "access_token", value: token)]
+            
+        case .imageUrl(_, let token):
+            return [URLQueryItem(name: "fields", value: "id,media_type,media_url,thumbnail_url"),
+                    URLQueryItem(name: "access_token", value: token)]
         }
+        
 
     }
 

--- a/Czechgram/Czechgram/DataLayer/Network/Service/NetworkService.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/Service/NetworkService.swift
@@ -39,6 +39,29 @@ struct NetworkService: NetworkServiceable {
             }.resume()
         }
     }
+
+    func requestImage(url: URL, completion: @escaping CompletionHandler) {
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            guard let httpResponse = response as? HTTPURLResponse else { return }
+
+            if let error = error {
+                completion(.failure(.transportError(error)))
+                return
+            }
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                completion(.failure(.serverError(statusCode: httpResponse.statusCode)))
+                return
+            }
+
+            guard let data = data else {
+                completion(.failure(.noData))
+                return
+            }
+
+            completion(.success(data))
+        }.resume()
+    }
 }
 
 private extension NetworkService {

--- a/Czechgram/Czechgram/DataLayer/Network/Service/NetworkService.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/Service/NetworkService.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct NetworkService: NetworkServiceable {
 
-    static func request(endPoint: EndPoint, completion: @escaping CompletionHandler) {
+    func request(endPoint: EndPoint, completion: @escaping CompletionHandler) {
 
         let request = makeURLRequest(with: endPoint)
         switch request {
@@ -39,8 +39,11 @@ struct NetworkService: NetworkServiceable {
             }.resume()
         }
     }
+}
 
-    static func makeURLRequest(with target: EndPoint) -> Result<URLRequest, NetworkError> {
+private extension NetworkService {
+
+    func makeURLRequest(with target: EndPoint) -> Result<URLRequest, NetworkError> {
         guard let url = target.url else { return .failure(.noData) }
 
         var request = URLRequest(url: url)

--- a/Czechgram/Czechgram/DataLayer/Network/Service/Protocol/NetworkServiceable.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/Service/Protocol/NetworkServiceable.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol NetworkServiceable {
     typealias CompletionHandler = (Result<Data, NetworkError>) -> Void
-    static func request(endPoint: EndPoint, completion: @escaping CompletionHandler)
+    func request(endPoint: EndPoint, completion: @escaping CompletionHandler)
 }

--- a/Czechgram/Czechgram/DataLayer/Network/Service/Protocol/NetworkServiceable.swift
+++ b/Czechgram/Czechgram/DataLayer/Network/Service/Protocol/NetworkServiceable.swift
@@ -5,9 +5,10 @@
 //  Created by juntaek.oh on 2022/07/12.
 //
 
-import Foundation
+import UIKit
 
 protocol NetworkServiceable {
     typealias CompletionHandler = (Result<Data, NetworkError>) -> Void
     func request(endPoint: EndPoint, completion: @escaping CompletionHandler)
+    func requestImage(url: URL, completion: @escaping CompletionHandler)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -11,4 +11,5 @@ protocol ViewMyPageRepository {
 
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void)
     func requestMediaData(with id: String, for completion: @escaping (UIImage?, String?) -> Void)
+    func requestNextPageMediaData(with validURL: URL, for completion: @escaping (MediaDTO?) -> Void)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -5,9 +5,10 @@
 //  Created by juntaek.oh on 2022/07/20.
 //
 
-import Foundation
+import UIKit
 
 protocol ViewMyPageRepository {
 
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void)
+    func requestMediaData(for completion: @escaping (UIImage?) -> Void)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -10,5 +10,5 @@ import UIKit
 protocol ViewMyPageRepository {
 
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void)
-    func requestMediaData(for completion: @escaping (UIImage?) -> Void)
+    func requestMediaData(with id: String, for completion: @escaping (UIImage?) -> Void)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol ViewMyPageRepository {
-    
-    func requestPageData()
+
+    func requestPageData(for completion: @escaping (UserPageDTO?) -> Void)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -10,5 +10,5 @@ import UIKit
 protocol ViewMyPageRepository {
 
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void)
-    func requestMediaData(with id: String, for completion: @escaping (UIImage?) -> Void)
+    func requestMediaData(with id: String, for completion: @escaping (UIImage?, String?) -> Void)
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/Protocol/ViewMyPageRepository.swift
@@ -1,0 +1,13 @@
+//
+//  ViewMyPageRepository.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+protocol ViewMyPageRepository {
+    
+    func requestPageData()
+}

--- a/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
@@ -8,8 +8,29 @@
 import Foundation
 
 final class ViewDefaultMyPageRepository: ViewMyPageRepository {
-    
-    func requestPageData() {
-        
+
+    let networkService: NetworkServiceable = NetworkService()
+
+    func requestPageData(for completion: @escaping (UserPageDTO?) -> Void) {
+        fetchUserPageData(with: completion)
+    }
+}
+
+private extension ViewDefaultMyPageRepository {
+
+    func fetchUserPageData(with completion: @escaping (UserPageDTO?) -> Void) {
+        guard let token = UserDefaults.standard.object(forKey: "accessToken") as? String else { return }
+
+        networkService.request(endPoint: EndPoint.userPage(token: token)) { result in
+            switch result {
+            case .success(let data):
+                let jsonConveter = JSONConverter<UserPageDTO>()
+                let userData: UserPageDTO? = jsonConveter.decode(data: data)
+                completion(userData)
+
+            case .failure:
+                print(NetworkError.noData)
+            }
+        }
     }
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
@@ -14,7 +14,7 @@ final class ViewDefaultMyPageRepository: ViewMyPageRepository {
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void) {
         fetchUserPageData(with: completion)
     }
-    
+
     func requestMediaData(with id: String, for completion: @escaping (UIImage?) -> Void) {
         guard let token = UserDefaults.standard.object(forKey: "accessToken") as? String else { return }
         networkService.request(endPoint: .imageUrl(mediaID: id, token: token)) { [weak self] result in
@@ -24,15 +24,15 @@ final class ViewDefaultMyPageRepository: ViewMyPageRepository {
                 let mediaUrlDTO = jsonConverter.decode(data: data)
                 guard let url: String = mediaUrlDTO?.mediaType == .Video ? mediaUrlDTO?.thumbnailUrl : mediaUrlDTO?.mediaUrl else { print(NetworkError.noURL)
                     return }
-                
-                self?.fetchUserImageData(with: url, completion: <#T##(UIImage) -> Void#>)
-            case .failure(let error):
+
+                self?.fetchUserImageData(with: url, completion: completion)
+            case .failure:
                 print(NetworkError.noData)
             }
         }
 
     }
-    
+
 }
 
 private extension ViewDefaultMyPageRepository {
@@ -52,8 +52,18 @@ private extension ViewDefaultMyPageRepository {
             }
         }
     }
-    
-    func fetchUserImageData(with url: String, completion: @escaping (UIImage) -> Void) {
-        
+
+    func fetchUserImageData(with url: String, completion: @escaping (UIImage?) -> Void) {
+        guard let url = URL(string: url) else { return }
+        networkService.requestImage(url: url) { result in
+            switch result {
+            case .success(let data):
+                let image = UIImage(data: data)
+                completion(image)
+            case .failure:
+                print(NetworkError.noData)
+
+            }
+        }
     }
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
@@ -29,7 +29,20 @@ final class ViewDefaultMyPageRepository: ViewMyPageRepository {
                 print(NetworkError.noData)
             }
         }
+    }
 
+    func requestNextPageMediaData(with validURL: URL, for completion: @escaping (MediaDTO?) -> Void) {
+        networkService.requestImage(url: validURL) { result in
+            switch result {
+            case .success(let data):
+                let jsonConverter = JSONConverter<MediaDTO>()
+                let dto = jsonConverter.decode(data: data)
+                completion(dto)
+
+            case .failure:
+                print(NetworkError.noData)
+            }
+        }
     }
 
 }

--- a/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
@@ -1,0 +1,15 @@
+//
+//  ViewDefaultMyPageRepository.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+final class ViewDefaultMyPageRepository: ViewMyPageRepository {
+    
+    func requestPageData() {
+        
+    }
+}

--- a/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
+++ b/Czechgram/Czechgram/DataLayer/Repository/ViewDefaultMyPageRepository.swift
@@ -5,7 +5,7 @@
 //  Created by juntaek.oh on 2022/07/20.
 //
 
-import Foundation
+import UIKit
 
 final class ViewDefaultMyPageRepository: ViewMyPageRepository {
 
@@ -14,6 +14,25 @@ final class ViewDefaultMyPageRepository: ViewMyPageRepository {
     func requestPageData(for completion: @escaping (UserPageDTO?) -> Void) {
         fetchUserPageData(with: completion)
     }
+    
+    func requestMediaData(with id: String, for completion: @escaping (UIImage?) -> Void) {
+        guard let token = UserDefaults.standard.object(forKey: "accessToken") as? String else { return }
+        networkService.request(endPoint: .imageUrl(mediaID: id, token: token)) { [weak self] result in
+            switch result {
+            case .success(let data):
+                let jsonConverter = JSONConverter<MediaUrlDTO>()
+                let mediaUrlDTO = jsonConverter.decode(data: data)
+                guard let url: String = mediaUrlDTO?.mediaType == .Video ? mediaUrlDTO?.thumbnailUrl : mediaUrlDTO?.mediaUrl else { print(NetworkError.noURL)
+                    return }
+                
+                self?.fetchUserImageData(with: url, completion: <#T##(UIImage) -> Void#>)
+            case .failure(let error):
+                print(NetworkError.noData)
+            }
+        }
+
+    }
+    
 }
 
 private extension ViewDefaultMyPageRepository {
@@ -32,5 +51,9 @@ private extension ViewDefaultMyPageRepository {
                 print(NetworkError.noData)
             }
         }
+    }
+    
+    func fetchUserImageData(with url: String, completion: @escaping (UIImage) -> Void) {
+        
     }
 }

--- a/Czechgram/Czechgram/DomainLayer/Entity/MediaEntity.swift
+++ b/Czechgram/Czechgram/DomainLayer/Entity/MediaEntity.swift
@@ -1,0 +1,14 @@
+//
+//  MediaEntity.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+struct MediaEntity {
+
+    var images: [MediaImageEntity]
+    let page: MediaPagingDTO
+}

--- a/Czechgram/Czechgram/DomainLayer/Entity/MediaImageEntity.swift
+++ b/Czechgram/Czechgram/DomainLayer/Entity/MediaImageEntity.swift
@@ -1,0 +1,14 @@
+//
+//  MediaImageEntity.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import UIKit
+
+struct MediaImageEntity {
+
+    let id: String
+    var image: UIImage?
+}

--- a/Czechgram/Czechgram/DomainLayer/Entity/MediaImageEntity.swift
+++ b/Czechgram/Czechgram/DomainLayer/Entity/MediaImageEntity.swift
@@ -11,4 +11,5 @@ struct MediaImageEntity {
 
     let id: String
     var image: UIImage?
+    var createdTime: Date?
 }

--- a/Czechgram/Czechgram/DomainLayer/Entity/UserPageEntity.swift
+++ b/Czechgram/Czechgram/DomainLayer/Entity/UserPageEntity.swift
@@ -1,0 +1,15 @@
+//
+//  UserPageEntity.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+struct UserPageEntity {
+
+    let userName: String
+    let mediaCount: Int
+    var media: MediaEntity
+}

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
@@ -11,5 +11,5 @@ protocol ViewMyPageUsecase {
 
     func executeUserPage(completion: @escaping (UserPageEntity) -> Void)
     func executeMediaImage(with imageEntity: MediaImageEntity, completion: @escaping (MediaImageEntity) -> Void)
-
+    func executeNextMediaImage(with nextImageSection: String?, completion: @escaping (MediaEntity?) -> Void)
 }

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
@@ -10,6 +10,6 @@ import Foundation
 protocol ViewMyPageUsecase {
 
     func executeUserPage(completion: @escaping (UserPageEntity) -> Void)
-    func executeMediaImage(with id: String, completion: @escaping (MediaImageEntity) -> Void)
-    
+    func executeMediaImage(with imageEntity: MediaImageEntity, completion: @escaping (MediaImageEntity) -> Void)
+
 }

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/Protocol/ViewMyPageUsecase.swift
@@ -10,4 +10,6 @@ import Foundation
 protocol ViewMyPageUsecase {
 
     func executeUserPage(completion: @escaping (UserPageEntity) -> Void)
+    func executeMediaImage(with id: String, completion: @escaping (MediaImageEntity) -> Void)
+    
 }

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
@@ -18,6 +18,11 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
             completion(entity)
         }
     }
+    
+    func executeMediaImage(with id: String, completion: @escaping (MediaImageEntity) -> Void) {
+        myPageRepository.requestMediaData()
+    }
+    
 }
 
 private extension ViewDefaultMyPageUsecase {

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
@@ -25,6 +25,7 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
             var entity = imageEntity
             entity.image = image
             entity.createdTime = date
+            // TODO: entity 저장 (캐시, 파일매니저)
             completion(entity)
         }
     }

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
@@ -13,7 +13,7 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
 
     func executeUserPage(completion: @escaping (UserPageEntity) -> Void) {
         myPageRepository.requestPageData { [weak self] userPageDTO in
-            guard let validDTO = userPageDTO, let entity = self?.convertEntity(from: validDTO) else { return }
+            guard let validDTO = userPageDTO, let entity = self?.convert(from: validDTO) else { return }
 
             completion(entity)
         }
@@ -30,17 +30,31 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
         }
     }
 
+    func executeNextMediaImage(with nextImageSection: String?, completion: @escaping (MediaEntity?) -> Void) {
+        guard let section = nextImageSection, let url = URL(string: section) else { return }
+        myPageRepository.requestNextPageMediaData(with: url) { [weak self] media in
+            guard let media = media else { return }
+            let mediaEntity = self?.convert(from: media)
+            completion(mediaEntity)
+        }
+    }
 }
 
 private extension ViewDefaultMyPageUsecase {
 
-    func convertEntity(from userDTO: UserPageDTO) -> UserPageEntity {
+    func convert(from mediaDTO: MediaDTO) -> MediaEntity {
         var imageEntity = [MediaImageEntity]()
-        userDTO.media.mediaIDs.forEach {
+        mediaDTO.mediaIDs.forEach {
             let entity = MediaImageEntity(id: $0.id)
             imageEntity.append(entity)
         }
-        let mediaEntity = MediaEntity(images: imageEntity, page: userDTO.media.paging)
+        let mediaEntity = MediaEntity(images: imageEntity, page: mediaDTO.paging)
+
+        return mediaEntity
+    }
+
+    func convert(from userDTO: UserPageDTO) -> UserPageEntity {
+        let mediaEntity = self.convert(from: userDTO.media)
         let userEntity = UserPageEntity(userName: userDTO.username, mediaCount: userDTO.mediaCount, media: mediaEntity)
         return userEntity
     }

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
@@ -18,11 +18,16 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
             completion(entity)
         }
     }
-    
-    func executeMediaImage(with id: String, completion: @escaping (MediaImageEntity) -> Void) {
-        myPageRepository.requestMediaData()
+
+    func executeMediaImage(with imageEntity: MediaImageEntity, completion: @escaping (MediaImageEntity) -> Void) {
+        myPageRepository.requestMediaData(with: imageEntity.id) { image in
+            guard let image = image else { return }
+            var entity = imageEntity
+            entity.image = image
+            completion(entity)
+        }
     }
-    
+
 }
 
 private extension ViewDefaultMyPageUsecase {

--- a/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/HomeUsecase/ViewDefaultMyPageUsecase.swift
@@ -39,6 +39,9 @@ private extension ViewDefaultMyPageUsecase {
             imageEntity.append(entity)
         }
 
+        imageEntity.sort { lhs, rhs in
+            lhs.id > rhs.id
+        }
         let mediaEntity = MediaEntity(images: imageEntity, page: userDTO.media.paging)
         let userEntity = UserPageEntity(userName: userDTO.username, mediaCount: userDTO.mediaCount, media: mediaEntity)
         return userEntity

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/InstagramLoginUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/InstagramLoginUsecase.swift
@@ -53,7 +53,6 @@ private extension InstagramLoginUsecase {
                 let accessToken = jsonData["access_token"] as? String else { return }
 
                 UserDefaults.standard.set(accessToken, forKey: "accessToken")
-                print(accessToken)
                 tokenCompletion(accessToken)
 
             case .failure(let error):

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol ViewMyPageUsecase {
-    
+
     func execute()
 }

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol ViewMyPageUsecase {
 
-    func execute()
+    func executeUserPage(completion: @escaping (UserPageEntity) -> Void)
 }

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/Protocol/ViewMyPageUsecase.swift
@@ -1,0 +1,13 @@
+//
+//  ViewMyPageUsecase.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+protocol ViewMyPageUsecase {
+    
+    func execute()
+}

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
@@ -11,10 +11,26 @@ final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
 
     let myPageRepository: ViewMyPageRepository = ViewDefaultMyPageRepository()
 
-    func execute() {
-        myPageRepository.requestPageData { userPageDTO in
-            guard let validDTO = userPageDTO else { return }
+    func executeUserPage(completion: @escaping (UserPageEntity) -> Void) {
+        myPageRepository.requestPageData { [weak self] userPageDTO in
+            guard let validDTO = userPageDTO, let entity = self?.convertEntity(from: validDTO) else { return }
 
+            completion(entity)
         }
+    }
+}
+
+private extension ViewDefaultMyPageUsecase {
+
+    func convertEntity(from userDTO: UserPageDTO) -> UserPageEntity {
+        var imageEntity = [MediaImageEntity]()
+        userDTO.media.mediaIDs.forEach {
+            let entity = MediaImageEntity(id: $0.id)
+            imageEntity.append(entity)
+        }
+
+        let mediaEntity = MediaEntity(images: imageEntity, page: userDTO.media.paging)
+        let userEntity = UserPageEntity(userName: userDTO.username, mediaCount: userDTO.mediaCount, media: mediaEntity)
+        return userEntity
     }
 }

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
@@ -1,0 +1,15 @@
+//
+//  ViewDefaultMyPageUsecase.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
+    
+    func execute() {
+        
+    }
+}

--- a/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
+++ b/Czechgram/Czechgram/DomainLayer/LoginUsecase/ViewDefaultMyPageUsecase.swift
@@ -8,8 +8,13 @@
 import Foundation
 
 final class ViewDefaultMyPageUsecase: ViewMyPageUsecase {
-    
+
+    let myPageRepository: ViewMyPageRepository = ViewDefaultMyPageRepository()
+
     func execute() {
-        
+        myPageRepository.requestPageData { userPageDTO in
+            guard let validDTO = userPageDTO else { return }
+
+        }
     }
 }

--- a/Czechgram/Czechgram/Helper/JSONConverter.swift
+++ b/Czechgram/Czechgram/Helper/JSONConverter.swift
@@ -1,0 +1,33 @@
+//
+//  JSONConverter.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+struct JSONConverter<T: Codable> {
+
+    typealias Model = T
+
+    func decode(data: Data) -> Model? {
+        do {
+            let decodedData = try JSONDecoder().decode(Model.self, from: data)
+            return decodedData
+        } catch {
+            print(NetworkError.decodingError(error))
+            return nil
+        }
+    }
+
+    func encode(model: Model) -> Data? {
+        do {
+            let encodedData = try JSONEncoder().encode(model)
+            return encodedData
+        } catch {
+            print(NetworkError.encodingError(error))
+            return nil
+        }
+    }
+}

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -64,12 +64,13 @@ private extension HomeViewController {
                 cell.set(image: image)
             }
 
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                self?.profileView.setProfileData(userName: userPageData.userName, postCount: userPageData.mediaCount)
                 self?.collectionView.dataSource = self?.datasource
+                self?.setContentViewHeight(imagesCount: userPageData.media.images.count)
                 self?.collectionView.reloadData()
             }
         }
-
     }
 
     func setNavigationController() {
@@ -111,14 +112,30 @@ private extension HomeViewController {
             collectionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             collectionView.widthAnchor.constraint(equalTo: contentView.widthAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            collectionView.heightAnchor.constraint(equalToConstant: 1500)
+            collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
 
     func setCollectionView() {
 
         self.collectionView.delegate = self
+    }
+
+    func setContentViewHeight(imagesCount: Int) {
+        var line = 0
+
+        if imagesCount % 3 == 0 {
+            line = imagesCount / 3
+
+        } else {
+            line = imagesCount / 3 + 1
+        }
+
+        let cellHeight = Int(collectionView.frame.width / 3 - 1)
+        let collectionViewHeight = CGFloat(cellHeight * line + 220)
+        NSLayoutConstraint.activate([
+            contentView.heightAnchor.constraint(equalToConstant: collectionViewHeight)
+        ])
     }
 }
 
@@ -130,8 +147,8 @@ private extension HomeViewController {
      }
 
      func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = collectionView.frame.width / 3 - 1
-        return CGSize(width: width, height: width)
+         let width = collectionView.frame.width / 3 - 1
+         return CGSize(width: width, height: width)
      }
 
      func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
@@ -141,4 +158,5 @@ private extension HomeViewController {
      func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
          return 1
      }
+
  }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -15,12 +15,12 @@ final class HomeViewController: UIViewController {
     private var datasource: CollectionViewDatasource<MediaImageEntity, PostCell>?
 
     private var scrollView: UIScrollView = {
-            let scrollView = UIScrollView()
-            scrollView.translatesAutoresizingMaskIntoConstraints = false
-            scrollView.backgroundColor = .white
-            scrollView.showsVerticalScrollIndicator = false
-            return scrollView
-        }()
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.backgroundColor = .white
+        scrollView.showsVerticalScrollIndicator = false
+        return scrollView
+    }()
 
     private var contentView: UIView = {
         let view = UIView()
@@ -28,12 +28,13 @@ final class HomeViewController: UIViewController {
         return view
     }()
 
-    private var collectionView: UICollectionView = {
+    private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.isScrollEnabled = false
         collectionView.register(PostCell.self, forCellWithReuseIdentifier: PostCell.reuseIdentifier)
+        collectionView.delegate = self
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -46,7 +47,6 @@ final class HomeViewController: UIViewController {
 
         setNavigationController()
         configureLayouts()
-        setCollectionView()
         configureBind()
         homeVM.enquireAllData()
     }
@@ -119,22 +119,10 @@ private extension HomeViewController {
         ])
     }
 
-    func setCollectionView() {
-
-        self.collectionView.delegate = self
-    }
-
     func setContentViewHeight(imagesCount: Int) {
         NSLayoutConstraint.deactivate(contentViewHeightConstraint)
 
-        var line = 0
-
-        if imagesCount % 3 == 0 {
-            line = imagesCount / 3
-
-        } else {
-            line = imagesCount / 3 + 1
-        }
+        let line = imagesCount % 3 == 0 ? imagesCount / 3 : imagesCount / 3 + 1
 
         let cellHeight = Int(collectionView.frame.width / 3 - 1)
         let collectionViewHeight = CGFloat((cellHeight * line) + (1 * line) + 220)

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -9,10 +9,10 @@ import UIKit
 
 final class HomeViewController: UIViewController {
 
-    let dummyData: [String] = ["userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage", "userImage"]
+    private var homeVM = HomeViewModel()
 
     private var profileView = ProfileView()
-    private var datasource: CollectionViewDatasource<String, PostCell>?
+    private var datasource: CollectionViewDatasource<MediaImageEntity, PostCell>?
 
     private var scrollView: UIScrollView = {
             let scrollView = UIScrollView()
@@ -45,6 +45,8 @@ final class HomeViewController: UIViewController {
         setNavigationController()
         configureLayouts()
         setCollectionView()
+        configureBind()
+        homeVM.enquireAllData()
     }
 
     override func viewDidLayoutSubviews() {
@@ -53,6 +55,20 @@ final class HomeViewController: UIViewController {
 }
 
 private extension HomeViewController {
+
+    func configureBind() {
+        homeVM.myPageData.bind { [weak self] userPageData in
+            guard let userPageData = userPageData else { return }
+            self?.datasource = CollectionViewDatasource(userPageData.media.images, reuseIdentifier: PostCell.reuseIdentifier) { (imageData: MediaImageEntity, cell: PostCell) in
+                guard let image = imageData.image else { return }
+                cell.set(image: image)
+            }
+            DispatchQueue.main.async {
+                self?.collectionView.reloadData()
+            }
+        }
+
+    }
 
     func setNavigationController() {
         let titleView = HomeNavigationTitleView()
@@ -99,9 +115,6 @@ private extension HomeViewController {
     }
 
     func setCollectionView() {
-        datasource = CollectionViewDatasource(dummyData, reuseIdentifier: PostCell.reuseIdentifier) { (imageData: String, cell: PostCell) in
-            cell.set(image: UIImage(named: imageData) ?? UIImage())
-        }
         self.collectionView.dataSource = self.datasource
         self.collectionView.delegate = self
     }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -122,12 +122,12 @@ private extension HomeViewController {
     func setContentViewHeight(imagesCount: Int) {
         NSLayoutConstraint.deactivate(contentViewHeightConstraint)
 
-        let line = imagesCount % 3 == 0 ? imagesCount / 3 : imagesCount / 3 + 1
+        let row = imagesCount % 3 == 0 ? imagesCount / 3 : imagesCount / 3 + 1
 
         let cellHeight = Int(collectionView.frame.width / 3 - 1)
-        let collectionViewHeight = CGFloat((cellHeight * line) + (1 * line) + 220)
+        let contentViewHeight = CGFloat((cellHeight * row) + (1 * row) + 220)
 
-        contentViewHeightConstraint = [contentView.heightAnchor.constraint(equalToConstant: collectionViewHeight)]
+        contentViewHeightConstraint = [contentView.heightAnchor.constraint(equalToConstant: contentViewHeight)]
         NSLayoutConstraint.activate(contentViewHeightConstraint)
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -38,6 +38,8 @@ final class HomeViewController: UIViewController {
         return collectionView
     }()
 
+    private var contentViewHeightConstraint = [NSLayoutConstraint]()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
@@ -69,6 +71,7 @@ private extension HomeViewController {
                 self?.collectionView.dataSource = self?.datasource
                 self?.setContentViewHeight(imagesCount: userPageData.media.images.count)
                 self?.collectionView.reloadData()
+                self?.scrollView.setNeedsLayout()
             }
         }
     }
@@ -122,6 +125,8 @@ private extension HomeViewController {
     }
 
     func setContentViewHeight(imagesCount: Int) {
+        NSLayoutConstraint.deactivate(contentViewHeightConstraint)
+
         var line = 0
 
         if imagesCount % 3 == 0 {
@@ -132,18 +137,19 @@ private extension HomeViewController {
         }
 
         let cellHeight = Int(collectionView.frame.width / 3 - 1)
-        let collectionViewHeight = CGFloat(cellHeight * line + 220)
-        NSLayoutConstraint.activate([
-            contentView.heightAnchor.constraint(equalToConstant: collectionViewHeight)
-        ])
+        let collectionViewHeight = CGFloat((cellHeight * line) + (1 * line) + 220)
+
+        contentViewHeightConstraint = [contentView.heightAnchor.constraint(equalToConstant: collectionViewHeight)]
+        NSLayoutConstraint.activate(contentViewHeightConstraint)
     }
 }
 
  extension HomeViewController: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
 
      func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-         let detailVC = DetailViewController()
-         self.navigationController?.pushViewController(detailVC, animated: true)
+//         let detailVC = DetailViewController()
+//         self.navigationController?.pushViewController(detailVC, animated: true)
+         self.homeVM.enquireNextImages()
      }
 
      func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -63,7 +63,9 @@ private extension HomeViewController {
                 guard let image = imageData.image else { return }
                 cell.set(image: image)
             }
+
             DispatchQueue.main.async {
+                self?.collectionView.dataSource = self?.datasource
                 self?.collectionView.reloadData()
             }
         }
@@ -115,7 +117,7 @@ private extension HomeViewController {
     }
 
     func setCollectionView() {
-        self.collectionView.dataSource = self.datasource
+
         self.collectionView.delegate = self
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/ProfileView.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/ProfileView.swift
@@ -13,14 +13,12 @@ final class ProfileView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.clipsToBounds = true
-        imageView.image = UIImage(named: "userImage")
 
         return imageView
     }()
 
     private var postsButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitle("7\n게시물", for: .normal)
         button.titleLabel?.numberOfLines = 2
         button.tintColor = .black
         button.titleLabel?.textAlignment = .center
@@ -30,7 +28,6 @@ final class ProfileView: UIView {
 
     private var followersButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitle("24\n팔로워", for: .normal)
         button.titleLabel?.numberOfLines = 2
         button.tintColor = .black
         button.titleLabel?.textAlignment = .center
@@ -40,7 +37,6 @@ final class ProfileView: UIView {
 
     private var followingButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitle("24\n팔로잉", for: .normal)
         button.titleLabel?.numberOfLines = 2
         button.tintColor = .black
         button.titleLabel?.textAlignment = .center
@@ -50,7 +46,6 @@ final class ProfileView: UIView {
 
     private var nameLabel: UILabel = {
         let label = UILabel()
-        label.text = "czech"
         label.font = UIFont.boldSystemFont(ofSize: 14)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -74,6 +69,14 @@ final class ProfileView: UIView {
     @available (*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func setProfileData(userName: String, postCount: Int) {
+        nameLabel.text = userName
+        postsButton.setTitle("\(postCount)\n게시물", for: .normal)
+        userImageView.image = UIImage(named: "userImage")
+        followersButton.setTitle("24\n팔로워", for: .normal)
+        followingButton.setTitle("24\n팔로잉", for: .normal)
     }
 
     func setUserImageCornerRoundly() {

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -9,9 +9,20 @@ import Foundation
 
 final class HomeViewModel {
 
+    var instaOAuthPageURL: Observable<UserPageEntity?> = Observable(nil)
+
     let myPageUsecase: ViewMyPageUsecase = ViewDefaultMyPageUsecase()
 
-    func enquiredAllData() {
+    func enquireAllData() {
+        myPageUsecase.executeUserPage { [weak self] userPage in
+            self?.enquireImages(with: userPage)
+        }
+    }
+}
+
+private extension HomeViewModel {
+
+    func enquireImages(with: UserPageEntity) {
 
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -1,0 +1,15 @@
+//
+//  HomeViewModel.swift
+//  Czechgram
+//
+//  Created by juntaek.oh on 2022/07/20.
+//
+
+import Foundation
+
+final class HomeViewModel {
+    
+    func enquiredAllData() {
+        
+    }
+}

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -8,8 +8,10 @@
 import Foundation
 
 final class HomeViewModel {
-    
+
+    let myPageUsecase: ViewMyPageUsecase = ViewDefaultMyPageUsecase()
+
     func enquiredAllData() {
-        
+
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -31,8 +31,12 @@ private extension HomeViewModel {
         entity.media.images.forEach {
             myPageUsecase.executeMediaImage(with: $0) { mediaEntity in
                 imageEntites.append(mediaEntity)
+
+                guard imageEntites.count != entity.media.images.count else {
+                    completion(imageEntites)
+                    return
+                }
             }
         }
-
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -16,8 +16,16 @@ final class HomeViewModel {
     func enquireAllData() {
         myPageUsecase.executeUserPage { [weak self] userPage in
             self?.enquireImages(with: userPage, completion: { [weak self] mediaImages in
+                let images = mediaImages.sorted { firstValue, secondValue in
+                    if let firstTime = firstValue.createdTime, let secondTime = secondValue.createdTime {
+                        return firstTime > secondTime
+                    } else {
+                        return firstValue.id > secondValue.id
+                    }
+                }
+
                 var completedUserPage = userPage
-                completedUserPage.media.images = mediaImages
+                completedUserPage.media.images = images
                 self?.myPageData.updateValue(value: completedUserPage)
             })
         }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -9,23 +9,30 @@ import Foundation
 
 final class HomeViewModel {
 
-    var instaOAuthPageURL: Observable<UserPageEntity?> = Observable(nil)
+    var myPageData: Observable<UserPageEntity?> = Observable(nil)
 
     let myPageUsecase: ViewMyPageUsecase = ViewDefaultMyPageUsecase()
 
     func enquireAllData() {
         myPageUsecase.executeUserPage { [weak self] userPage in
-            self?.enquireImages(with: userPage)
+            self?.enquireImages(with: userPage, completion: { [weak self] mediaImages in
+                var completedUserPage = userPage
+                completedUserPage.media.images = mediaImages
+                self?.myPageData.updateValue(value: completedUserPage)
+            })
         }
     }
 }
 
 private extension HomeViewModel {
 
-    func enquireImages(with entity: UserPageEntity) {
+    func enquireImages(with entity: UserPageEntity, completion : @escaping ([MediaImageEntity]) -> Void) {
+        var imageEntites = [MediaImageEntity]()
         entity.media.images.forEach {
-            myPageUsecase.executeMediaImage(with: $0.id)
+            myPageUsecase.executeMediaImage(with: $0) { mediaEntity in
+                imageEntites.append(mediaEntity)
+            }
         }
-        
+
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -15,7 +15,7 @@ final class HomeViewModel {
 
     func enquireAllData() {
         myPageUsecase.executeUserPage { [weak self] userPage in
-            self?.enquireImages(with: userPage, completion: { [weak self] mediaImages in
+            self?.enquireImages(with: userPage.media, completion: { [weak self] mediaImages in
                 let images = mediaImages.sorted { firstValue, secondValue in
                     if let firstTime = firstValue.createdTime, let secondTime = secondValue.createdTime {
                         return firstTime > secondTime
@@ -30,17 +30,37 @@ final class HomeViewModel {
             })
         }
     }
+
+    func enquireNextImages() {
+        myPageUsecase.executeNextMediaImage(with: myPageData.value?.media.page.next) { [weak self] mediaEntity in
+            guard let mediaEntity = mediaEntity else { return }
+            self?.enquireImages(with: mediaEntity, completion: { [weak self] mediaImages in
+                let images = mediaImages.sorted { firstValue, secondValue in
+                    if let firstTime = firstValue.createdTime, let secondTime = secondValue.createdTime {
+                        return firstTime > secondTime
+                    } else {
+                        return firstValue.id > secondValue.id
+                    }
+                }
+
+                guard let userPage = self?.myPageData.value else { return }
+                var refreshedUserPage = userPage
+                refreshedUserPage.media.images.append(contentsOf: images)
+                self?.myPageData.updateValue(value: refreshedUserPage)
+            })
+        }
+    }
 }
 
 private extension HomeViewModel {
 
-    func enquireImages(with entity: UserPageEntity, completion : @escaping ([MediaImageEntity]) -> Void) {
+    func enquireImages(with entity: MediaEntity, completion : @escaping ([MediaImageEntity]) -> Void) {
         var imageEntites = [MediaImageEntity]()
-        entity.media.images.forEach {
+        entity.images.forEach {
             myPageUsecase.executeMediaImage(with: $0) { mediaEntity in
                 imageEntites.append(mediaEntity)
 
-                guard imageEntites.count != entity.media.images.count else {
+                guard imageEntites.count != entity.images.count else {
                     completion(imageEntites)
                     return
                 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -22,7 +22,10 @@ final class HomeViewModel {
 
 private extension HomeViewModel {
 
-    func enquireImages(with: UserPageEntity) {
-
+    func enquireImages(with entity: UserPageEntity) {
+        entity.media.images.forEach {
+            myPageUsecase.executeMediaImage(with: $0.id)
+        }
+        
     }
 }

--- a/Czechgram/Czechgram/PresentationLayer/LoginScene/ViewModel/LoginViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/LoginScene/ViewModel/LoginViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by juntaek.oh on 2022/07/12.
 //
 
-import UIKit
+import Foundation
 
 final class LoginViewModel {
 

--- a/Czechgram/Czechgram/SceneDelegate.swift
+++ b/Czechgram/Czechgram/SceneDelegate.swift
@@ -13,13 +13,42 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        window = UIWindow(windowScene: windowScene)
 
-        // TODO: 후에 변경 해야함
-        let mainViewController = LoginViewController()
+        if let token = UserDefaults.standard.object(forKey: "accessToken") as? String {
+            let networkService = NetworkService()
+            networkService.request(endPoint: EndPoint.userPage(token: token)) { result in
+                switch result {
+                case .success:
+                    DispatchQueue.main.async {
+                        self.window = UIWindow(windowScene: windowScene)
+                        let mainViewController = HomeViewController()
+                        let naviController = UINavigationController(rootViewController: mainViewController)
 
-        window?.rootViewController = mainViewController
-        window?.makeKeyAndVisible()
+                        self.window?.rootViewController = naviController
+                        self.window?.makeKeyAndVisible()
+                    }
+
+                case .failure:
+                    DispatchQueue.main.async {
+                        self.window = UIWindow(windowScene: windowScene)
+                        let mainViewController = LoginViewController()
+
+                        self.window?.rootViewController = mainViewController
+                        self.window?.makeKeyAndVisible()
+                    }
+                }
+            }
+
+        } else {
+            DispatchQueue.main.async {
+                self.window = UIWindow(windowScene: windowScene)
+                let mainViewController = LoginViewController()
+
+                self.window?.rootViewController = mainViewController
+                self.window?.makeKeyAndVisible()
+            }
+        }
+
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {


### PR DESCRIPTION
#17 

## 작업 내역
- [x]  AccessToken - SceneDelegate에서 확인 후, 바로 Home 화면 넘어오는 로직 구현
- [x]  FileManager image cache 및 데이터 로컬 저장 구현
    - [ ]  데이터 로컬 저장 미구현
- [x]  HomeVC 사용자 닉네임, 게시물 수 관련 데이터-View 연결
- [x]  화면 스크롤 시, 다음 페이지 이미지들 추가 기능 구현
    - [ ]  화면 스크롤에 따른 이미지 추가 미구현
- [x]  HomeView CollectionView 높이 조정