### PR TITLE
Home 화면에서 스크롤을 해 추가 이미지 불러오기

### DIFF
--- a/Czechgram/Czechgram.xcodeproj/project.pbxproj
+++ b/Czechgram/Czechgram.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6FFB6391C18D03BDD1B39D73 /* Pods_Czechgram.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B8395B4FD5F0B8CBFCD1C25 /* Pods_Czechgram.framework */; };
+		B34F386D288E6DA600505C1D /* LoadingReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34F386C288E6DA600505C1D /* LoadingReusableView.swift */; };
 		B37747DB287BBA0200E2599B /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DA287BBA0200E2599B /* HomeViewController.swift */; };
 		B37747DD287BBCC800E2599B /* HomeNavigationTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DC287BBCC800E2599B /* HomeNavigationTitleView.swift */; };
 		B37747DF287BED7D00E2599B /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37747DE287BED7C00E2599B /* ProfileView.swift */; };
@@ -57,6 +58,7 @@
 /* Begin PBXFileReference section */
 		2C1CA1BA3CAEE782D8C6E777 /* Pods-Czechgram.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Czechgram.debug.xcconfig"; path = "Target Support Files/Pods-Czechgram/Pods-Czechgram.debug.xcconfig"; sourceTree = "<group>"; };
 		7B8395B4FD5F0B8CBFCD1C25 /* Pods_Czechgram.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Czechgram.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B34F386C288E6DA600505C1D /* LoadingReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingReusableView.swift; sourceTree = "<group>"; };
 		B37747DA287BBA0200E2599B /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		B37747DC287BBCC800E2599B /* HomeNavigationTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeNavigationTitleView.swift; sourceTree = "<group>"; };
 		B37747DE287BED7C00E2599B /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 				B37747DC287BBCC800E2599B /* HomeNavigationTitleView.swift */,
 				B37747DE287BED7C00E2599B /* ProfileView.swift */,
 				B37747E0287C146000E2599B /* PostCell.swift */,
+				B34F386C288E6DA600505C1D /* LoadingReusableView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -560,6 +563,7 @@
 				D262352D287C03DC002F0610 /* UIView +.swift in Sources */,
 				B3F115BF2888F7A1001B498C /* ImageCacheService.swift in Sources */,
 				B3AD44212887F7BA00A9B59E /* MediaUrlDTO.swift in Sources */,
+				B34F386D288E6DA600505C1D /* LoadingReusableView.swift in Sources */,
 				B3F23FEB287D607E00E06E85 /* Endpoint.swift in Sources */,
 				D2623527287BF572002F0610 /* CollectionViewDatasource.swift in Sources */,
 				D2525A3E2887E4C100078D1C /* UserPageEntity.swift in Sources */,

--- a/Czechgram/Czechgram/Helper/Observable.swift
+++ b/Czechgram/Czechgram/Helper/Observable.swift
@@ -11,7 +11,7 @@ final class Observable<T> {
     typealias Listener = ((T) -> Void)
 
     private var listener: Listener?
-    var value: T {
+    private(set) var value: T {
         didSet {
             listener?(value)
         }

--- a/Czechgram/Czechgram/PresentationLayer/DetailScene/View/CollectionViewDatasource.swift
+++ b/Czechgram/Czechgram/PresentationLayer/DetailScene/View/CollectionViewDatasource.swift
@@ -33,4 +33,16 @@ final class CollectionViewDatasource<Model, Cell: UICollectionViewCell>: NSObjec
         cellConfigurator(models[indexPath.row], cell)
         return cell
     }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard kind == UICollectionView.elementKindSectionFooter else { return UICollectionReusableView() }
+        guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: LoadingReusableView.reuseIdentifier, for: indexPath) as? LoadingReusableView else { return UICollectionReusableView()}
+
+        return footer
+    }
+
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/HomeViewController.swift
@@ -46,7 +46,7 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .white
-
+        self.scrollView.delegate = self
         setNavigationController()
         configureLayouts()
         configureBind()
@@ -127,7 +127,7 @@ private extension HomeViewController {
         let row = imagesCount % 3 == 0 ? imagesCount / 3 : imagesCount / 3 + 1
 
         let cellHeight = Int(collectionView.frame.width / 3 - 1)
-        let contentViewHeight = CGFloat((cellHeight * row) + (1 * row) + 220 + 100)
+        let contentViewHeight = CGFloat((cellHeight * row) + (1 * row) + 220 + 60)
 
         contentViewHeightConstraint = [contentView.heightAnchor.constraint(equalToConstant: contentViewHeight)]
         NSLayoutConstraint.activate(contentViewHeightConstraint)
@@ -157,13 +157,12 @@ private extension HomeViewController {
      // MARK: Loading Footer Settings
      func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForFooterInSection section: Int) -> CGSize {
 
-         // 로딩중이거나, 모든 데이터를 가지고 왔다면
-         if homeVM.isFetchAllData || homeVM.isLoading {
-             return CGSize.zero // 로딩창 안보이게 설정
+         // 로딩중이 아니거나, 모든 데이터를 가지고 왔다면
+         if homeVM.isFetchAllData || !homeVM.isLoading {
+             return CGSize.zero
          } else {
              return CGSize(width: collectionView.frame.width, height: 50)
          }
-
      }
 
      // footer appear
@@ -173,7 +172,6 @@ private extension HomeViewController {
          if elementKind == UICollectionView.elementKindSectionFooter && homeVM.isLoading {
                      footer.activityIndicator.startAnimating()
              } else {
-
                  footer.activityIndicator.stopAnimating()
              }
 
@@ -186,19 +184,18 @@ private extension HomeViewController {
                  footer.activityIndicator.stopAnimating()
              }
          }
+ }
 
-     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-
-         if homeVM.isFetchAllData {
-                 print("no more Image")
+extension HomeViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if homeVM.isFetchAllData {
+             print("no more Image")
          } else {
-             // 보고있는 이미지가 마지막 이미지이고, 로딩중이 아닐때
-             guard let imagesCount: Int = homeVM.myPageData.value?.media.images.count else { return }
-                    if indexPath.row ==  imagesCount - 1 && homeVM.isLoading == false {
-                        homeVM.enquireNextImages()
-                    }
+             let scrollViewHeight = scrollView.frame.size.height
+             let scrollOffset = scrollView.contentOffset.y
+             if !homeVM.isLoading && (scrollViewHeight - scrollOffset < 30) {
+                 homeVM.enquireNextImages()
              }
-
          }
-
+     }
  }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
@@ -1,0 +1,55 @@
+//
+//  LoadingReusableView.swift
+//  Czechgram
+//
+//  Created by 최예주 on 2022/07/25.
+//
+
+import UIKit
+
+final class LoadingReusableView: UICollectionReusableView {
+
+    var homeVM = HomeViewModel()
+    static let reuseIdentifier = "LoadingFooter"
+
+    private(set) var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView()
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+//        indicator.hidesWhenStopped = true
+        indicator.stopAnimating()
+        return indicator
+
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.backgroundColor = .clear
+        configureLayouts()
+    }
+
+    @available (*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+//    func loadAddtionalData() {
+//        self.activityIndicator.startAnimating()
+//        homeVM.enquireNextImages()
+//    }
+
+}
+
+private extension LoadingReusableView {
+
+    func configureLayouts() {
+        self.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            activityIndicator.topAnchor.constraint(equalTo: self.topAnchor),
+            activityIndicator.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            activityIndicator.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            activityIndicator.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+
+        ])
+    }
+}

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class LoadingReusableView: UICollectionReusableView {
 
-    var homeVM = HomeViewModel()
     static let reuseIdentifier = "LoadingFooter"
 
     private(set) var activityIndicator: UIActivityIndicatorView = {

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/View/LoadingReusableView.swift
@@ -15,7 +15,6 @@ final class LoadingReusableView: UICollectionReusableView {
     private(set) var activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
         indicator.translatesAutoresizingMaskIntoConstraints = false
-//        indicator.hidesWhenStopped = true
         indicator.stopAnimating()
         return indicator
 
@@ -31,11 +30,6 @@ final class LoadingReusableView: UICollectionReusableView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-//    func loadAddtionalData() {
-//        self.activityIndicator.startAnimating()
-//        homeVM.enquireNextImages()
-//    }
 
 }
 

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -12,8 +12,15 @@ final class HomeViewModel {
     var myPageData: Observable<UserPageEntity?> = Observable(nil)
 
     let myPageUsecase: ViewMyPageUsecase = ViewDefaultMyPageUsecase()
+    var isAvailableAdditionalFetching: Observable<Bool> = Observable(false)
+    var isLoading: Bool = false
+
+    private(set) lazy var isFetchAllData: Bool = {
+        return myPageData.value?.mediaCount == myPageData.value?.media.images.count
+    }()
 
     func enquireAllData() {
+        isAvailableAdditionalFetching.updateValue(value: false)
         myPageUsecase.executeUserPage { [weak self] userPage in
             self?.enquireImages(with: userPage.media, completion: { [weak self] mediaImages in
                 let images = mediaImages.sorted { firstValue, secondValue in
@@ -27,6 +34,7 @@ final class HomeViewModel {
                 var completedUserPage = userPage
                 completedUserPage.media.images = images
                 self?.myPageData.updateValue(value: completedUserPage)
+
             })
         }
     }
@@ -47,6 +55,8 @@ final class HomeViewModel {
                 var refreshedUserPage = userPage
                 refreshedUserPage.media.images.append(contentsOf: images)
                 self?.myPageData.updateValue(value: refreshedUserPage)
+                sleep(2)
+                self?.isAvailableAdditionalFetching.updateValue(value: false)
             })
         }
     }
@@ -67,4 +77,5 @@ private extension HomeViewModel {
             }
         }
     }
+
 }

--- a/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
+++ b/Czechgram/Czechgram/PresentationLayer/HomeScene/ViewModel/HomeViewModel.swift
@@ -10,16 +10,14 @@ import Foundation
 final class HomeViewModel {
 
     var myPageData: Observable<UserPageEntity?> = Observable(nil)
-
     let myPageUsecase: ViewMyPageUsecase = ViewDefaultMyPageUsecase()
-    var isLoading: Bool = false
 
     var isFetchAllData: Bool {
         return myPageData.value?.mediaCount == myPageData.value?.media.images.count
     }
 
     func enquireAllData() {
-        isLoading = true
+
         myPageUsecase.executeUserPage { [weak self] userPage in
             self?.enquireImages(with: userPage.media, completion: { [weak self] mediaImages in
                 let images = mediaImages.sorted { firstValue, secondValue in
@@ -29,22 +27,15 @@ final class HomeViewModel {
                         return firstValue.id > secondValue.id
                     }
                 }
-
                 var completedUserPage = userPage
                 completedUserPage.media.images = images
                 self?.myPageData.updateValue(value: completedUserPage)
-
-                DispatchQueue.global().async {
-                    sleep(2)
-                    self?.isLoading = false
-                }
-
             })
         }
     }
 
     func enquireNextImages() {
-        isLoading = true
+
         myPageUsecase.executeNextMediaImage(with: myPageData.value?.media.page.next) { [weak self] mediaEntity in
             guard let mediaEntity = mediaEntity else { return }
             self?.enquireImages(with: mediaEntity, completion: { [weak self] mediaImages in
@@ -55,17 +46,10 @@ final class HomeViewModel {
                         return firstValue.id > secondValue.id
                     }
                 }
-
                 guard let userPage = self?.myPageData.value else { return }
                 var refreshedUserPage = userPage
                 refreshedUserPage.media.images.append(contentsOf: images)
                 self?.myPageData.updateValue(value: refreshedUserPage)
-
-                DispatchQueue.global().async {
-                    sleep(2)
-                    self?.isLoading = false
-                }
-
             })
         }
     }


### PR DESCRIPTION
#18  

## 고민과 해결 
- `enquireAllData()` 시작 시점에서 isLoading 의 값을 true로 설정하고 끝나는 시점에서 false로 설정함으로써 Lock을 걸어주는 로직으로 구현 
    - isLoading이 true일 경우에만 로딩 footer가 보이게 설정을 해주니 fetch로직 실행시간이 짧아 보이지 않는 현상 발생 
    - 비동기로 몇초간 대기를 하여 로딩footer가 보이는 시간을 주고, 다시 값을 셋팅해주는 방법으로 로직 변경 

- 스크롤을 끝까지 했을 때를 어떻게 알아야 할까. 
    - `func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell ` 메소드를 사용해 현재 보이는 셀의 indexPath를 얻어와서 구현하고자 함 
    - collectionView자체가 ScrollView 안에 들어있기 때문에 스크롤을 하지 않아도 모든 셀들이 뷰안에 들어있는 상태여서 원하는 기능을 구현하지 못함 
    - collectionView.visibleCells() 도 같은 이유 
    - scrollView Delegate 메소드를 사용해 화면끝까지 내려갔는지를 판단.